### PR TITLE
make it use php-fpm

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -12,6 +12,13 @@ apps:
     daemon: simple
     plugs: [listener]
 
+  # php-fpm - this certainly needs work
+  php-fpm:
+    command: php-fpm
+    stop-command: php-fpm stop
+    daemon: simple
+    plugs: [listener]
+    
   # MySQL daemon
   mysql:
     command: start_mysql
@@ -77,6 +84,7 @@ parts:
           - --with-bz2
           - --with-mcrypt
           - --enable-exif
+          - --enable-fpm
     stage:
       - -htdocs/.git*
     snap:
@@ -100,6 +108,7 @@ parts:
     plugin: copy
     files:
       src/php/php.ini: php.ini
+      src/php/php-fpm.conf: php-fpm.conf
 
   # Copy over our ownCloud configuration files
   owncloud-config:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -61,7 +61,9 @@ parts:
       - authz_core
       - unixd
       - alias
-
+      - proxy
+      - proxy_fcgi
+    
     # Extra Apache configuration for ownCloud (and PHP)
     extra-configuration: src/owncloud/apache_config
 

--- a/src/owncloud/apache_config
+++ b/src/owncloud/apache_config
@@ -14,3 +14,16 @@ Alias "/apps" "${SNAP_DATA}/owncloud/apps"
 <IfModule dir_module>
     DirectoryIndex index.html index.php
 </IfModule>
+
+<IfModule proxy_fcgi_module>
+	<Proxy "unix:/var/run/php.socket|fcgi://php-fpm" timeout=300>
+	</Proxy>
+</IfModule>
+
+<Directory "${SNAP}">
+	<IfModule proxy_fcgi_module>
+		<FilesMatch \.php$>
+			SetHandler "proxy:fcgi://php-fpm/"
+		</FilesMatch>
+	</IfModule>
+</Directory>

--- a/src/owncloud/apache_config
+++ b/src/owncloud/apache_config
@@ -15,6 +15,7 @@ Alias "/apps" "${SNAP_DATA}/owncloud/apps"
     DirectoryIndex index.html index.php
 </IfModule>
 
+# add fpm
 <IfModule proxy_fcgi_module>
 	<Proxy "unix:/var/run/php.socket|fcgi://php-fpm" timeout=300>
 	</Proxy>
@@ -27,3 +28,7 @@ Alias "/apps" "${SNAP_DATA}/owncloud/apps"
 		</FilesMatch>
 	</IfModule>
 </Directory>
+
+# this should route all php files though fpm - note that fpm has to run with the same rights as apache (to own the files)
+ProxyPassMatch ^/(.*\.php(/.*)?)$ fcgi://127.0.0.1:9000/srv/www/htdocs/owncloud/$1
+DirectoryIndex /index.php index.php

--- a/src/php/php-fpm.conf
+++ b/src/php/php-fpm.conf
@@ -1,0 +1,24 @@
+[site]
+listen = 127.0.0.1:9000
+user = www-data
+group = www-data
+request_slowlog_timeout = 5s
+slowlog = /dev/null
+listen.allowed_clients = 127.0.0.1
+pm = dynamic
+pm.max_children = 9
+pm.start_servers = 3
+pm.min_spare_servers = 2
+pm.max_spare_servers = 4
+pm.max_requests = 200
+listen.backlog = -1
+pm.status_path = /status
+request_terminate_timeout = 120s
+rlimit_files = 131072
+rlimit_core = unlimited
+catch_workers_output = yes
+env[HOSTNAME] = $HOSTNAME
+env[TMP] = /tmp
+env[TMPDIR] = /tmp
+env[TEMP] = /tmp
+pid = /var/run/php-fpm.pid # open question: do we need to specify a PID file?


### PR DESCRIPTION
So I thought enabling fpm wouldn't be so hard ;-)

What a deep hole I found myself in... Anybody around here willing to dig in with me?

The basics are there but I haven't yet tested it. what is missing, for sure, is the init part - I'm not sure how to get an init script working.

What does this do?
- compile php-fpm in (in the snapcraft)
- make sure it starts as daemon (in the snapcraft)
- configure php-fpm (adding a config file)
- enable using php-fpm in apache (in the apache_config file)

I have not yet tested it so the chances this work are around freezing point. I did get it to work on my own server but that doesn't run snappy atm.

@kyrofa @oparoz @ezraholm @enoch85 what do you think, could any of you give this a try perhaps?
