### PR TITLE
Increase max upload to 16GB.

### DIFF
--- a/src/owncloud/setup_owncloud
+++ b/src/owncloud/setup_owncloud
@@ -29,6 +29,9 @@ fi
 # Make sure owncloud directory exists
 mkdir -p $SNAP_DATA/owncloud
 
+# Make sure owncloud tmp directory exists
+mkdir -p $SNAP_DATA/owncloud/tmp
+
 # Make sure apps are up to date
 echo "Ensuring ownCloud apps are up-to-date..."
 OWNCLOUD_APPS_DIR=$SNAP_DATA/owncloud/apps

--- a/src/php/php.ini
+++ b/src/php/php.ini
@@ -653,7 +653,7 @@ auto_globals_jit = On
 ; Its value may be 0 to disable the limit. It is ignored if POST data reading
 ; is disabled through enable_post_data_reading.
 ; http://php.net/post-max-size
-post_max_size = 8M
+post_max_size = 16G
 
 ; Automatically add files before PHP document.
 ; http://php.net/auto-prepend-file
@@ -792,11 +792,11 @@ file_uploads = On
 ; Temporary directory for HTTP uploaded files (will use system default if not
 ; specified).
 ; http://php.net/upload-tmp-dir
-;upload_tmp_dir =
+upload_tmp_dir = ${SNAP_DATA}/owncloud/tmp
 
 ; Maximum allowed size for uploaded files.
 ; http://php.net/upload-max-filesize
-upload_max_filesize = 2M
+upload_max_filesize = 16G
 
 ; Maximum number of files that can be uploaded via a single request
 max_file_uploads = 20


### PR DESCRIPTION
This PR fixes #5 by using `$SNAP_DATA/owncloud/tmp` instead of `/tmp` as the `upload_tmp_dir` and also updating the `upload_max_filesize` and `upload_max_filesize` in `php.ini`.
