### PR TITLE
Use PHP-FPM instead of mod_php

### DIFF
--- a/parts/plugins/x-apache.py
+++ b/parts/plugins/x-apache.py
@@ -183,7 +183,7 @@ class ApachePlugin(snapcraft.BasePlugin):
 
         shutil.copytree(apache_source_directory, apache_build_directory)
 
-        subprocess.check_call("./configure --prefix={} --enable-modules=none --enable-mods-shared='{}' ENABLED_DSO_MODULES='{}'".format(self.installdir, ' '.join(self.options.modules), ','.join(self.options.modules)),
+        subprocess.check_call("./configure --prefix={} --with-mpm=event --enable-modules=none --enable-mods-shared='{}' ENABLED_DSO_MODULES='{}'".format(self.installdir, ' '.join(self.options.modules), ','.join(self.options.modules)),
                               cwd=apache_build_directory, shell=True)
 
         self.run(
@@ -245,7 +245,6 @@ class ApachePlugin(snapcraft.BasePlugin):
 
             configure_command = [
                 './configure', '--prefix=' + self.installdir,
-                '--with-apxs2={}/bin/apxs'.format(self.installdir),
                 '--disable-rpath']
 
             self.run(configure_command + module.configflags,

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: owncloud
-version: 9.0.0ubuntu1
+version: 9.0.1ubuntu1
 summary: ownCloud
 description: ownCloud running on Apache with MySQL. This is currently in beta.
 
@@ -44,7 +44,7 @@ parts:
     plugin: apache
     source: https://github.com/kyrofa/owncloud.git
     source-type: git
-    source-tag: 9.0.0
+    source-tag: 9.0.1
 
     # The built-in Apache modules to enable
     modules:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: owncloud
 version: 9.0.1ubuntu1
 summary: ownCloud
-description: ownCloud running on Apache with MySQL. This is currently in beta.
+description: ownCloud running on Apache using PHP-FPM with MySQL. This is currently in beta.
 
 apps:
   # Apache daemon
@@ -9,6 +9,13 @@ apps:
     command: apachectl start -DFOREGROUND
     stop-command: apachectl stop
     daemon: simple
+    plugs: [listener]
+
+  # PHP-FPM daemon
+  php-fpm:
+    command: php-fpm start
+    stop-command: php-fpm stop
+    daemon: forking
     plugs: [listener]
 
   # MySQL daemon
@@ -34,12 +41,24 @@ apps:
     command: occ
     plugs: [listener]
 
+  # phpinfo() command
+  phpinfo:
+    command: phpinfo
+    plugs: [listener]
+
 plugs:
   listener:
     interface: old-security
     caps: [network-listener]
 
 parts:
+  # Copy over some general setup scripts
+  setup-scripts:
+    plugin: copy
+    files:
+      src/setup/filesystem.sh: setup/
+      src/setup/hw_rating.sh: setup/
+
   apache:
     plugin: apache
     source: https://github.com/kyrofa/owncloud.git
@@ -49,7 +68,8 @@ parts:
     # The built-in Apache modules to enable
     modules:
       - headers
-      - fcgid
+      - proxy
+      - proxy_fcgi
       - setenvif
       - env
       - rewrite
@@ -60,46 +80,33 @@ parts:
       - alias
 
     # Extra Apache configuration for ownCloud (and PHP)
+    # Do not comment out as it places a call to the config in httpd.conf
     extra-configuration: src/owncloud/apache_config
 
     # Script to run before bringing up Apache
+    # Do not comment out as it places a call to the script in envvars
     startup-script: src/owncloud/setup_owncloud
 
-    third-party-modules:
-      # Build PHP
-      - source: http://us1.php.net/get/php-7.0.2.tar.gz/from/this/mirror
-        source-type: tar
-        configflags:
-          - --enable-ctype
-          - --enable-mbstring
-          - --enable-zip
-          - --with-pdo-mysql
-          - --with-zlib
-          - --with-gd
-          - --with-curl
-          - --with-openssl
-          - --with-bz2
-          - --with-mcrypt
-          - --enable-exif
     stage:
       - -htdocs/.git*
+      - -conf/extra_configuration
+      - -bin/startup_script
     snap:
       - -manual # No need to include the documentation in the .snap
       - -htdocs/.git*
-    stage-packages:
-      - libxml2 # Only included here until the OS snap stabilizes
-    build-packages:
-      - libxml2-dev
-      - libcurl4-openssl-dev
-      - libpng12-dev
-      - libbz2-dev
-      - libmcrypt-dev
+      - -htdocs/.user.ini
+      - -conf/extra_configuration
+      - -bin/startup_script
 
-  # Copy over our PHP configuration file.
-  php-config:
+  # Copy over our Apache configuration files
+  apache-customizations:
     plugin: copy
+    after: [apache]
     files:
-      src/php/php.ini: php.ini
+      src/owncloud/apache_config: conf/extra_configuration
+      src/owncloud/userconfigs/platform.conf: conf/userconfigs/
+      src/owncloud/userconfigs/custom.conf: conf/userconfigs/
+      src/owncloud/setup_owncloud: bin/startup_script
 
   # Copy over our ownCloud configuration files
   owncloud-customizations:
@@ -107,6 +114,60 @@ parts:
     files:
       src/owncloud/*config.php: htdocs/config/
       src/owncloud/occ: bin/
+
+  php:
+    plugin: autotools
+    source: http://us1.php.net/get/php-7.0.5.tar.gz/from/this/mirror
+    source-type: tar
+    install-via: prefix
+    configflags:
+      - --enable-fpm
+      - --disable-cgi
+      - --disable-phar
+      - --disable-phpdbg
+      - --enable-ctype
+      - --enable-mbstring
+      - --enable-zip
+      - --with-pdo-mysql
+      - --with-zlib
+      - --with-gd
+      - --enable-gd-native-ttf
+      - --with-jpeg-dir=/usr/lib
+      - --with-freetype-dir=/usr/lib
+      - --with-curl
+      - --with-openssl
+      - --with-bz2
+      - --with-mcrypt
+      - --enable-exif
+      - --enable-intl
+      - --enable-pcntl
+      - --disable-rpath
+    stage-packages:
+      - libxml2 # Only included here until the OS snap stabilizes
+      - libpng12-0
+      - libfreetype6
+      - libfontconfig1
+    build-packages:
+      - libfontconfig1-dev
+      - libfreetype6-dev
+      - libjpeg8-dev
+      - libxml2-dev
+      - libcurl4-openssl-dev
+      - libpng12-dev
+      - libbz2-dev
+      - libmcrypt-dev
+
+  # Copy over our PHP configuration file.
+  php-customizations:
+    plugin: copy
+    files:
+      src/php/php.ini: php/lib/
+      src/php/extensions.ini: php/lib/php.conf.d/
+      src/php/php-fpm.conf: php/etc/
+      src/php/userconfigs/platform.conf: php/userconfigs/
+      src/php/userconfigs/custom.conf: php/userconfigs/
+      src/php/php-fpm: bin/
+      src/php/phpinfo: bin/
 
   # Download the boost headers for MySQL. Note that the version used may need to
   # be updated if the version of MySQL changes.

--- a/src/owncloud/apache_config
+++ b/src/owncloud/apache_config
@@ -1,8 +1,9 @@
-<FilesMatch \.php$>
-    SetHandler application/x-httpd-php
+# PHP-FPM
+SetEnvIfNoCase ^Authorization$ "(.+)" HTTP_AUTHORIZATION=$1
+ProxyTimeout 900
+<FilesMatch "\.(inc|php)$">
+	SetHandler "proxy:unix:${SNAP_DATA}/var/tmp/php-fpm.sock|fcgi://localhost"
 </FilesMatch>
-
-PHPIniDir "${SNAP}/php.ini"
 
 # Serve static assets for apps in a writable location.
 Alias "/apps" "${SNAP_DATA}/owncloud/apps"
@@ -19,12 +20,9 @@ Alias "/apps" "${SNAP_DATA}/owncloud/apps"
     # as to avoid manually copying it in and needing to maintain it.
     Include ${SNAP}/htdocs/.htaccess
 
-    # Increase the max upload size, and upload into a different tmp so we don't
-    # try to use that much RAM.
-    php_value upload_max_filesize 16G
-    php_value post_max_size 16G
-    php_value upload_tmp_dir ${SNAP_DATA}/owncloud/tmp
-
     # Note that nothing else is included here as this directive is merged with
     # the one in the main configuration file.
 </Directory>
+
+Include ${SNAP_DATA}/apache/conf/platform.conf
+Include ${SNAP_DATA}/apache/conf/custom.conf

--- a/src/owncloud/apache_config
+++ b/src/owncloud/apache_config
@@ -11,6 +11,20 @@ Alias "/apps" "${SNAP_DATA}/owncloud/apps"
     Require all granted
 </Directory>
 
-<IfModule dir_module>
-    DirectoryIndex index.html index.php
-</IfModule>
+<Directory "${SNAP}/htdocs">
+    # Include ownCloud's .htaccess file directly. In a typical setup this would
+    # be dangerous since it increases the capability of the .htaccess file in
+    # case an attacker was able to modify it, but that's not actually possible
+    # on Snappy (since the .htaccess file is read-only) so we'll do it here so
+    # as to avoid manually copying it in and needing to maintain it.
+    Include ${SNAP}/htdocs/.htaccess
+
+    # Increase the max upload size, and upload into a different tmp so we don't
+    # try to use that much RAM.
+    php_value upload_max_filesize 16G
+    php_value post_max_size 16G
+    php_value upload_tmp_dir ${SNAP_DATA}/owncloud/tmp
+
+    # Note that nothing else is included here as this directive is merged with
+    # the one in the main configuration file.
+</Directory>

--- a/src/owncloud/autoconfig.php
+++ b/src/owncloud/autoconfig.php
@@ -12,16 +12,19 @@ if ($snap_developer != '') {
 
 $data_path = '/var/lib/snaps/'.$snap_name.'/current';
 
-$AUTOCONFIG = array(
-'directory' => $data_path.'/owncloud/data',
+$writable = getenv('SNAP_DATA');
+$owncloud_password = trim(file_get_contents($writable . '/mysql/owncloud_password'));
 
-'dbtype' => 'mysql',
+$AUTOCONFIG = [
+	'directory' => $data_path . '/owncloud/data',
 
-'dbhost' => 'localhost:'.$data_path.'/mysql/mysql.sock',
+	'dbtype' => 'mysql',
 
-'dbname' => 'owncloud',
+	'dbhost' => 'localhost:' . $data_path . '/mysql/mysql.sock',
 
-'dbuser' => 'owncloud',
+	'dbname' => 'owncloud',
 
-'dbpass' => getenv('OWNCLOUD_DATABASE_PASSWORD'),
-);
+	'dbuser' => 'owncloud',
+
+	'dbpass' => $owncloud_password,
+];

--- a/src/owncloud/setup_owncloud
+++ b/src/owncloud/setup_owncloud
@@ -1,4 +1,9 @@
 #!/bin/sh
+############################################
+# This script is called by /bin/envvars
+############################################
+#
+. $SNAP/setup/filesystem.sh
 
 mysqld_pid_file_path=$SNAP_DATA/mysql/`hostname`.pid
 # Wait for mysql to be up and running, since we need to make sure
@@ -16,10 +21,7 @@ while [ $timeout -gt 0 -a ! -e $owncloud_password_path ]; do
 	timeout=$((timeout-1))
 	sleep 1
 done
-if [ -e $owncloud_password_path ]; then
-	echo "owncloud mysql credentials successfully obtained"
-	export OWNCLOUD_DATABASE_PASSWORD=$(cat $owncloud_password_path)
-else
+if [ ! -e $owncloud_password_path ]; then
 	echo -n "Timed out while attempting to obtain owncloud mysql password. "
 	echo -n "This isn't unusual when starting up for the first time after "
 	echo "an install or an upgrade. Will try again."

--- a/src/owncloud/userconfigs/custom.conf
+++ b/src/owncloud/userconfigs/custom.conf
@@ -1,0 +1,4 @@
+#####################################################################################
+# Use this file to override variables set in the default Apache configuration
+# WARNING: This could break or slow down your ownCloud instance
+#####################################################################################

--- a/src/owncloud/userconfigs/platform.conf
+++ b/src/owncloud/userconfigs/platform.conf
@@ -1,0 +1,10 @@
+# MPM Event
+# MaxRequestWorkers is automatically calculated as ServerLimit x ThreadsPerChild
+<IfModule event.c>
+	StartServers XXXX
+	MinSpareThreads XXXX
+	MaxSpareThreads XXXX
+	ThreadsPerChild XXXX
+	MaxConnectionsPerChild 500
+	ServerLimit XXXX
+</IfModule>

--- a/src/php/extensions.ini
+++ b/src/php/extensions.ini
@@ -1,0 +1,3 @@
+; Extensions are located in $SNAP/lib/php/extensions/no-debug-non-zts-20151012
+; OpCache
+zend_extension=${SNAP}/lib/php/extensions/no-debug-non-zts-20151012/opcache.so

--- a/src/php/php-fpm
+++ b/src/php/php-fpm
@@ -1,0 +1,167 @@
+#!/bin/sh
+#
+# Startup script for PHP-FPM based on the directadmin.com script
+#
+# chkconfig: 345 85 15
+# description: PHP-FPM server
+# processname: php-fpm
+# config: $SNAP_DATA/php/php-fpm.conf
+. $SNAP/setup/filesystem.sh
+
+PID=$VAR_RUN/php-fpm.pid
+BIN=$SNAP/sbin/php-fpm
+
+RO_PHP_FOLDER=$SNAP/php
+RW_PHP_FOLDER=$SNAP_DATA/php
+PHP_CONF=$RO_PHP_FOLDER/lib/php.ini
+PHP_FPM_CONF=$RO_PHP_FOLDER/etc/php-fpm.conf
+PHP_USER_CONF=$RW_PHP_FOLDER/lib/php.conf.d
+
+# Tells PHP where to find its configuration files
+PHP_INI_SCAN_DIR=$RO_PHP_FOLDER/lib/php.conf.d:$PHP_USER_CONF
+export PHP_INI_SCAN_DIR
+
+OPTS="-R --daemonize --pid=${PID} --fpm-config $PHP_FPM_CONF -c $PHP_CONF -p $SNAP_DATA"
+
+status() {
+	local pid
+
+	# Test syntax.
+	if [ $# = 0 ] ; then
+			echo "Usage: status {program}"
+			return 1
+	fi
+
+	# First try "pidof"
+	pid=`$PID $1`
+	if [ "$pid" != "" ] ; then
+			echo "${1} (pid $pid) is running..."
+			return 0
+	fi
+
+	echo "${1} is stopped"
+	return 3
+}
+
+wait_for_pid () {
+	try=0
+
+	while test $try -lt 35 ; do
+		case "$1" in
+			'created')
+			if [ -f "$2" ] ; then
+				try=''
+				break
+			fi
+			;;
+
+			'removed')
+			if [ ! -f "$2" ] ; then
+				try=''
+				break
+			fi
+			;;
+		esac
+
+		echo -n .
+		try=`expr $try + 1`
+		sleep 1
+	done
+}
+
+
+case "$1" in
+	start)
+		echo -n "Starting php-fpm: "
+		$BIN $OPTS
+
+		if [ "$?" != 0 ] ; then
+			echo " failed"
+			exit 1
+		fi
+
+		wait_for_pid created $PID
+
+		if [ -n "$try" ] ; then
+			echo " failed"
+			exit 1
+		else
+			echo " done"
+		fi
+	;;
+
+ 	stop)
+		echo -n "Gracefully shutting down php-fpm: "
+
+		if [ ! -r $PID ] ; then
+			echo "warning, no pid file found - php-fpm is not running ?"
+			exit 1
+		fi
+
+		kill -QUIT `cat $PID`
+
+		wait_for_pid removed $PID
+
+		if [ -n "$try" ] ; then
+			echo " failed. Use force-quit"
+			exit 1
+		else
+			echo " done"
+		fi
+	;;
+
+	force-quit)
+		echo -n "Terminating php-fpm: "
+
+		if [ ! -r $PID ] ; then
+			echo "warning, no pid file found - php-fpm is not running ?"
+			exit 1
+		fi
+
+		kill -TERM `cat $PID`
+
+		wait_for_pid removed $PID
+
+		if [ -n "$try" ] ; then
+			echo " failed"
+			exit 1
+		else
+			echo " done"
+		fi
+	;;
+
+	restart)
+		$0 stop
+		$0 start
+	;;
+
+	reload)
+		echo -n "Reloading service php-fpm: "
+		if [ ! -r $PID ] ; then
+			echo "warning, no pid file found - php-fpm is not running ?"
+			exit 1
+		fi
+
+		kill -USR1 `cat $PID`
+
+		echo " done"
+	;;
+
+	graceful)
+		echo -n "Gracefully reloading service php-fpm: "
+		if [ ! -r $PID ] ; then
+			echo "warning, no pid file found - php-fpm is not running ?"
+			exit 1
+		fi
+
+		kill -USR2 `cat $PID`
+
+		echo " done"
+	;;
+
+	*)
+		echo -n "Usage: $0 {start|stop|restart|force-quit|reload|graceful}"
+		exit 1
+	;;
+esac
+exit 0;

--- a/src/php/php-fpm.conf
+++ b/src/php/php-fpm.conf
@@ -1,0 +1,61 @@
+[global]
+error_log = var/log/php-fpm.log
+
+; Log level
+; Possible Values: alert, error, warning, notice, debug
+; Default Value: notice
+log_level = notice
+
+;;;;;;;;;;;;;;;;;;;;
+; Pool Definitions ;
+;;;;;;;;;;;;;;;;;;;;
+
+[owncloud]
+user = root
+group = root
+
+; WARNING: paths are prefixed and in PHP land that means NOT starting with a slash...
+listen = var/tmp/php-fpm.sock
+; Any process using setuid is instantly killed
+;listen.owner = $pool
+;listen.group = $pool
+;listen.mode = 660
+
+; Redirect worker stdout and stderr into main error log. If not set, stdout and
+; stderr will be redirected to /dev/null according to FastCGI specs.
+; Note: on highloaded environement, this can cause some delay in the page
+; process time (several ms).
+; Default Value: no
+catch_workers_output = yes
+
+security.limit_extensions = .inc .php
+
+; Pass environment variables like LD_LIBRARY_PATH. All $VARIABLEs are taken from
+; the current environment.
+; Default Value: clean env = yes
+clear_env = no
+; We need this for ownCloud to understand where the config is located
+env[OWNCLOUD_CONFIG_DIR] = ${SNAP_DATA}/owncloud/config
+
+; Unnecessary unless we clear the environement variables
+;env[SNAP] = ${SNAP}
+;env[SNAP_DATA] = ${SNAP_DATA}
+;env[SNAP_NAME] = ${SNAP_NAME}
+; Keep commented out as we can't pass empty variables...
+;env[SNAP_DEVELOPER] = ${SNAP_DEVELOPER}
+;env[SNAP_ORIGIN] = ${SNAP_ORIGIN}
+
+;env[HOSTNAME] = localhost
+;env[PATH] = /usr/local/bin:/usr/bin:/bin
+
+; If we want to set open_basedir one day
+;php_admin_value[open_basedir] = var/tmp/:${SNAP}/lib/php:php
+
+; Temp folders
+;env[TMP] = ${SNAP_DATA}/var/tmp/
+;env[TMPDIR] = ${SNAP_DATA}/var/tmp/
+;env[TEMP] = ${SNAP_DATA}/var/tmp/
+php_admin_value[upload_tmp_dir] = ${SNAP_DATA}/var/tmp/
+
+; Include the user config
+include = php/etc/php-fpm.d/*.conf

--- a/src/php/php.ini
+++ b/src/php/php.ini
@@ -653,7 +653,7 @@ auto_globals_jit = On
 ; Its value may be 0 to disable the limit. It is ignored if POST data reading
 ; is disabled through enable_post_data_reading.
 ; http://php.net/post-max-size
-post_max_size = 16G
+post_max_size = 8M
 
 ; Automatically add files before PHP document.
 ; http://php.net/auto-prepend-file
@@ -792,11 +792,11 @@ file_uploads = On
 ; Temporary directory for HTTP uploaded files (will use system default if not
 ; specified).
 ; http://php.net/upload-tmp-dir
-upload_tmp_dir = ${SNAP_DATA}/owncloud/tmp
+;upload_tmp_dir =
 
 ; Maximum allowed size for uploaded files.
 ; http://php.net/upload-max-filesize
-upload_max_filesize = 16G
+upload_max_filesize = 2M
 
 ; Maximum number of files that can be uploaded via a single request
 max_file_uploads = 20

--- a/src/php/php.ini
+++ b/src/php/php.ini
@@ -186,7 +186,7 @@
 
 ; Enable the PHP scripting language engine under Apache.
 ; http://php.net/engine
-engine = On
+engine = Off
 
 ; This directive determines whether or not PHP will recognize code between
 ; <? and ?> tags as PHP source which should be processed as such. It is
@@ -720,7 +720,7 @@ user_dir =
 
 ; Directory in which the loadable extensions (modules) reside.
 ; http://php.net/extension-dir
-; extension_dir = "./"
+extension_dir = "${SNAP}/lib/php/extensions/no-debug-non-zts-20151012"
 ; On windows:
 ; extension_dir = "ext"
 

--- a/src/php/phpinfo
+++ b/src/php/phpinfo
@@ -1,11 +1,9 @@
 #!/bin/sh
 
-export OWNCLOUD_CONFIG_DIR=$SNAP_DATA/owncloud/config
-
 # Tells PHP where to find its configuration files
 RO_PHP_FOLDER=$SNAP/php
 RW_PHP_FOLDER=$SNAP_DATA/php
 PHP_INI_SCAN_DIR=$RO_PHP_FOLDER/lib/php.conf.d:$RW_PHP_FOLDER/lib/php.conf.d
 export PHP_INI_SCAN_DIR
 
-php -c $RO_PHP_FOLDER/lib $SNAP/htdocs/occ $*
+php -c $RO_PHP_FOLDER/lib -i

--- a/src/php/userconfigs/custom.conf
+++ b/src/php/userconfigs/custom.conf
@@ -1,0 +1,147 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; This is where you can tune your PHP configuration
+; WARNING: This could break or slow down your ownCloud instance
+;
+; ** php_value/php_flag **
+; you can set classic ini defines which can be overwritten from PHP call 'ini_set'.
+;
+; ** php_admin_value/php_admin_flag **
+; These directives won't be overwritten by PHP call 'ini_set'
+; For php_*flag, valid values are on, off, 1, 0, true, false, yes or no.
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+; ownCloud defaults
+php_value[upload_max_filesize] = 16G
+php_value[post_max_size] = 16G
+php_admin_flag[mbstring.func_overload] = off
+php_value[default_charset] = 'UTF-8'
+php_flag[output_buffering] = off
+
+; Logging
+;php_flag[display_errors] = on
+php_admin_flag[log_errors] = on
+php_admin_value[error_reporting] = 22527
+; WARNING: paths are prefixed and should NOT start with a slash
+php_admin_value[error_log] = var/log/php.error.log
+;access.log = var/log/php.access.log
+;access.format = "%R - %u %t \"%m %r%Q%q\" %s %f %{mili}d %{kilo}M %C%%"
+;slowlog = var/log/php.log.slow
+;request_slowlog_timeout = 0
+;request_terminate_timeout = 30s
+
+
+; The URI to view the FPM status page. If this value is not set, no URI will be
+; recognized as a status page. It shows the following informations:
+;   pool                 - the name of the pool;
+;   process manager      - static, dynamic or ondemand;
+;   start time           - the date and time FPM has started;
+;   start since          - number of seconds since FPM has started;
+;   accepted conn        - the number of request accepted by the pool;
+;   listen queue         - the number of request in the queue of pending
+;                          connections (see backlog in listen(2));
+;   max listen queue     - the maximum number of requests in the queue
+;                          of pending connections since FPM has started;
+;   listen queue len     - the size of the socket queue of pending connections;
+;   idle processes       - the number of idle processes;
+;   active processes     - the number of active processes;
+;   total processes      - the number of idle + active processes;
+;   max active processes - the maximum number of active processes since FPM
+;                          has started;
+;   max children reached - number of times, the process limit has been reached,
+;                          when pm tries to start more children (works only for
+;                          pm 'dynamic' and 'ondemand');
+; Value are updated in real time.
+; Example output:
+;   pool:                 www
+;   process manager:      static
+;   start time:           01/Jul/2011:17:53:49 +0200
+;   start since:          62636
+;   accepted conn:        190460
+;   listen queue:         0
+;   max listen queue:     1
+;   listen queue len:     42
+;   idle processes:       4
+;   active processes:     11
+;   total processes:      15
+;   max active processes: 12
+;   max children reached: 0
+;
+; By default the status page output is formatted as text/plain. Passing either
+; 'html', 'xml' or 'json' in the query string will return the corresponding
+; output syntax. Example:
+;   http://www.foo.bar/status
+;   http://www.foo.bar/status?json
+;   http://www.foo.bar/status?html
+;   http://www.foo.bar/status?xml
+;
+; By default the status page only outputs short status. Passing 'full' in the
+; query string will also return status for each pool process.
+; Example:
+;   http://www.foo.bar/status?full
+;   http://www.foo.bar/status?json&full
+;   http://www.foo.bar/status?html&full
+;   http://www.foo.bar/status?xml&full
+; The Full status returns for each process:
+;   pid                  - the PID of the process;
+;   state                - the state of the process (Idle, Running, ...);
+;   start time           - the date and time the process has started;
+;   start since          - the number of seconds since the process has started;
+;   requests             - the number of requests the process has served;
+;   request duration     - the duration in µs of the requests;
+;   request method       - the request method (GET, POST, ...);
+;   request URI          - the request URI with the query string;
+;   content length       - the content length of the request (only with POST);
+;   user                 - the user (PHP_AUTH_USER) (or '-' if not set);
+;   script               - the main script called (or '-' if not set);
+;   last request cpu     - the %cpu the last request consumed
+;                          it's always 0 if the process is not in Idle state
+;                          because CPU calculation is done when the request
+;                          processing has terminated;
+;   last request memory  - the max amount of memory the last request consumed
+;                          it's always 0 if the process is not in Idle state
+;                          because memory calculation is done when the request
+;                          processing has terminated;
+; If the process is in Idle state, then informations are related to the
+; last request the process has served. Otherwise informations are related to
+; the current request being served.
+; Example output:
+;   ************************
+;   pid:                  31330
+;   state:                Running
+;   start time:           01/Jul/2011:17:53:49 +0200
+;   start since:          63087
+;   requests:             12808
+;   request duration:     1250261
+;   request method:       GET
+;   request URI:          /test_mem.php?N=10000
+;   content length:       0
+;   user:                 -
+;   script:               /home/fat/web/docs/php/test_mem.php
+;   last request cpu:     0.00
+;   last request memory:  0
+;
+; Note: There is a real-time FPM status monitoring sample web page available
+;       It's available in: @EXPANDED_DATADIR@/fpm/status.html
+;
+; Note: The value must start with a leading slash (/). The value can be
+;       anything, but it may not be a good idea to use the .php extension or it
+;       may conflict with a real PHP file.
+; Default Value: not set
+;pm.status_path = /status
+
+; The ping URI to call the monitoring page of FPM. If this value is not set, no
+; URI will be recognized as a ping page. This could be used to test from outside
+; that FPM is alive and responding, or to
+; - create a graph of FPM availability (rrd or such);
+; - remove a server from a group if it is not responding (load balancing);
+; - trigger alerts for the operating team (24/7).
+; Note: The value must start with a leading slash (/). The value can be
+;       anything, but it may not be a good idea to use the .php extension or it
+;       may conflict with a real PHP file.
+; Default Value: not set
+;ping.path = /ping
+
+; This directive may be used to customize the response of a ping request. The
+; response is formatted as text/plain with a 200 response code.
+; Default Value: pong
+;ping.response = pong

--- a/src/php/userconfigs/platform.conf
+++ b/src/php/userconfigs/platform.conf
@@ -1,0 +1,74 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; THIS AUTOMATICALLY GENERATED CONFIGURATION IS OPTIMISED FOR YOUR PLATFORM
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+; Choose how the process manager will control the number of child processes.
+; Possible Values:
+;   static  - a fixed number (pm.max_children) of child processes;
+;   dynamic - the number of child processes are set dynamically based on the
+;             following directives. With this process management, there will be
+;             always at least 1 children.
+;             pm.max_children      - the maximum number of children that can
+;                                    be alive at the same time.
+;             pm.start_servers     - the number of children created on startup.
+;             pm.min_spare_servers - the minimum number of children in 'idle'
+;                                    state (waiting to process). If the number
+;                                    of 'idle' processes is less than this
+;                                    number then some children will be created.
+;             pm.max_spare_servers - the maximum number of children in 'idle'
+;                                    state (waiting to process). If the number
+;                                    of 'idle' processes is greater than this
+;                                    number then some children will be killed.
+;  ondemand - no children are created at startup. Children will be forked when
+;             new requests will connect. The following parameter are used:
+;             pm.max_children           - the maximum number of children that
+;                                         can be alive at the same time.
+;             pm.process_idle_timeout   - The number of seconds after which
+;                                         an idle process will be killed.
+; Note: This value is mandatory.
+pm = dynamic
+
+; The number of child processes to be created when pm is set to 'static' and the
+; maximum number of child processes when pm is set to 'dynamic' or 'ondemand'.
+; This value sets the limit on the number of simultaneous requests that will be
+; served. Equivalent to the ApacheMaxClients directive with mpm_prefork.
+; Note: Used when pm is set to 'static', 'dynamic' or 'ondemand'
+; Note: This value is mandatory.
+pm.max_children = XXXX
+
+; The number of child processes created on startup.
+; Note: Used only when pm is set to 'dynamic'
+; Default Value: min_spare_servers + (max_spare_servers - min_spare_servers) / 2
+pm.start_servers = XXXX
+
+; The desired minimum number of idle server processes.
+; Note: Used only when pm is set to 'dynamic'
+; Note: Mandatory when pm is set to 'dynamic'
+pm.min_spare_servers = XXXX
+
+; The desired maximum number of idle server processes.
+; Note: Used only when pm is set to 'dynamic'
+; Note: Mandatory when pm is set to 'dynamic'
+pm.max_spare_servers = XXXX
+
+; The number of seconds after which an idle process will be killed.
+; Note: Used only when pm is set to 'ondemand'
+; Default Value: 10s
+;pm.process_idle_timeout = 60s
+
+; The number of requests each child process should execute before respawning.
+; This can be useful to work around memory leaks in 3rd party libraries. For
+; endless request processing specify '0'. Equivalent to PHP_FCGI_MAX_REQUESTS.
+; Default Value: 0
+pm.max_requests = 200
+
+; The maximum amount of memory allowed PER PROCESS
+; You need to raise this limit if you intend on processing large images
+php_admin_value[memory_limit] = XXXX
+
+; The timeout for serving a single request after which the worker process will
+; be killed. This option should be used when the 'max_execution_time' ini option
+; does not stop script execution for some reason. A value of '0' means 'off'.
+; Available units: s(econds)(default), m(inutes), h(ours), or d(ays)
+; Default Value: 0
+request_terminate_timeout = 120

--- a/src/setup/filesystem.sh
+++ b/src/setup/filesystem.sh
@@ -1,0 +1,101 @@
+#!/bin/sh
+#
+# Defines a structure which can be used by all apps in this snap
+# Sets up Apache
+# Sets up PHP-FPM
+#
+VAR=$SNAP_DATA/var
+VAR_RUN=$VAR/run
+VAR_TMP=$VAR/tmp
+VAR_LOG=$VAR/log
+
+# Wait if the config is being created
+while [ -f $VAR_TMP/apache_php_config_lock ]; do
+	sleep 1
+done
+
+# @param $1 String to look for
+# @param $2 String to replace with
+# @param $3 Files to perform action on
+search_and_replace() {
+	{ rm $3 && awk '{gsub("'"${1}"'", "'"${2}"'", $0); print}'> $3; } < $3
+}
+
+if [ ! -f $VAR/apache_php_config_done ]; then
+	# Setup writable partition
+	if [ ! -d "$VAR_RUN" ] || [ ! -d "$VAR_TMP" ] || [ ! -d "$VAR_LOG" ]; then
+		echo "Configuring writeable partition..."
+		mkdir -p $VAR_RUN
+		mkdir -p $VAR_TMP
+		mkdir -p $VAR_LOG
+	fi
+	touch $VAR_TMP/apache_php_config_lock
+
+	PHP_MAX_SPARE_SERVERS_DEFAULT=3
+	PHP_MIN_SPARE_SERVERS_DEFAULT=1
+	PHP_START_SERVERS_DEFAULT=2
+	PHP_MAX_CHILDREN_DEFAULT=5
+	PHP_MEMORY_LIMIT_DEFAULT=128
+
+	APACHE_SERVER_LIMIT_DEFAULT=16
+	APACHE_THREADS_PER_CHILD=25
+	APACHE_APACHE_MIN_SPARE_THREADS_DEFAULT=75
+	APACHE_APACHE_MAX_SPARE_THREADS_DEFAULT=250
+	APACHE_START_SERVERS=3
+
+	# Calculates config values for PHP-FPM and Apache
+	. $SNAP/setup/hw_rating.sh
+	if [ "$?" != 0 ] ; then
+		echo "Auto-configuration failed..."
+		echo "Using default..."
+		PHP_MAX_SPARE_SERVERS=PHP_MAX_SPARE_SERVERS_DEFAULT
+		PHP_MIN_SPARE_SERVERS=PHP_MIN_SPARE_SERVERS_DEFAULT
+		PHP_START_SERVERS=PHP_START_SERVERS_DEFAULT
+		PHP_MAX_CHILDREN=PHP_MAX_CHILDREN_DEFAULT
+		PHP_MEMORY_LIMIT=PHP_MEMORY_LIMIT_DEFAULT
+
+		APACHE_SERVER_LIMIT=APACHE_SERVER_LIMIT_DEFAULT
+		APACHE_APACHE_MIN_SPARE_THREADS=APACHE_APACHE_MIN_SPARE_THREADS_DEFAULT
+		APACHE_APACHE_MAX_SPARE_THREADS=APACHE_APACHE_MAX_SPARE_THREADS_DEFAULT
+	else
+		echo "Auto-configuration was successful!"
+	fi
+
+	RO_PHP_FOLDER=$SNAP/php
+	RW_PHP_FOLDER=$SNAP_DATA/php
+	PHP_USER_CONF=$RW_PHP_FOLDER/lib/php.conf.d
+	PHP_FPM_USER_CONF=$RW_PHP_FOLDER/etc/php-fpm.d
+
+	# Setup PHP
+	if [ ! -d "$PHP_USER_CONF" ]; then
+		echo "Configuring PHP-FPM..."
+		mkdir -p $PHP_USER_CONF
+		mkdir -p $PHP_FPM_USER_CONF
+		touch $VAR_LOG/php-fpm.log
+		cp $RO_PHP_FOLDER/userconfigs/platform.conf $PHP_FPM_USER_CONF
+		cp $RO_PHP_FOLDER/userconfigs/custom.conf $PHP_FPM_USER_CONF
+		search_and_replace "pm.max_children = XXXX" "pm.max_children = "${PHP_MAX_CHILDREN} $PHP_FPM_USER_CONF"/platform.conf"
+		search_and_replace "pm.start_servers = XXXX" "pm.start_servers = "${PHP_START_SERVERS} $PHP_FPM_USER_CONF"/platform.conf"
+		search_and_replace "pm.min_spare_servers = XXXX" "pm.min_spare_servers = "${PHP_MIN_SPARE_SERVERS} $PHP_FPM_USER_CONF"/platform.conf"
+		search_and_replace "pm.max_spare_servers = XXXX" "pm.max_spare_servers = "${PHP_MAX_SPARE_SERVERS} $PHP_FPM_USER_CONF"/platform.conf"
+		search_and_replace "php_admin_value\[memory_limit\] = XXXX" "php_admin_value[memory_limit] = "${PHP_MEMORY_LIMIT}"M" "$PHP_FPM_USER_CONF/platform.conf"
+	fi
+
+	# Setup Apache
+	RO_APACHE_CONF_FOLDER=${SNAP}/conf
+	RW_APACHE_CONF_FOLDER=${SNAP_DATA}/apache/conf
+	if [ ! -d "$RW_APACHE_CONF_FOLDER" ]; then
+		echo "Configuring Apache..."
+		mkdir -p $RW_APACHE_CONF_FOLDER
+		cp $RO_APACHE_CONF_FOLDER/userconfigs/platform.conf $RW_APACHE_CONF_FOLDER
+		cp $RO_APACHE_CONF_FOLDER/userconfigs/custom.conf $RW_APACHE_CONF_FOLDER
+		search_and_replace "StartServers XXXX" "StartServers "${APACHE_START_SERVERS} $RW_APACHE_CONF_FOLDER"/platform.conf"
+		search_and_replace "MinSpareThreads XXXX" "MinSpareThreads "${APACHE_MIN_SPARE_THREADS} $RW_APACHE_CONF_FOLDER"/platform.conf"
+		search_and_replace "MaxSpareThreads XXXX" "MaxSpareThreads "${APACHE_MAX_SPARE_THREADS} $RW_APACHE_CONF_FOLDER"/platform.conf"
+		search_and_replace "ThreadsPerChild XXXX" "ThreadsPerChild "${APACHE_THREADS_PER_CHILD} $RW_APACHE_CONF_FOLDER"/platform.conf"
+		search_and_replace "ServerLimit XXXX" "ServerLimit "${APACHE_SERVER_LIMIT} "$RW_APACHE_CONF_FOLDER/platform.conf"
+	fi
+
+	touch $VAR/apache_php_config_done
+	rm -f $VAR_TMP/apache_php_config_lock
+fi

--- a/src/setup/hw_rating.sh
+++ b/src/setup/hw_rating.sh
@@ -1,0 +1,105 @@
+#!/bin/sh
+##################################################################
+# Script to determine the best
+# - Apache MPM_event
+# - PHP-FPM
+# settings when using ownCloud
+#
+# WARNING: Currently only works on Linux
+#
+# Copyright 2016 Olivier Paroz (owncloud@oparoz.com)
+# Licence GPL 3.0
+##################################################################
+validate_params() {
+	if [ $1 -gt 0 ] && [ -n "$1" ]; then
+		echo $1
+	else
+		echo $2
+	fi
+}
+
+echo "##################################################################"
+echo "# HARDWARE"
+echo "##################################################################"
+ARCH=$(uname -i)
+IS_ARM=$(echo $ARCH | awk '{print substr($0,0,4)}')
+
+# CPU Speed
+if [ $IS_ARM = "arm" ]; then
+	CPU_CORES=$(awk '/^processor/ {count++} END{print count}' /proc/cpuinfo)
+	CPU_SPEED=$(( `cat /sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq` /1000 ))
+	BOGOMIPS=$(awk '/^BogoMIPS/ {printf "%d", $3;exit}' /proc/cpuinfo)
+else
+	CPU_CORES=$(awk '/^cpu cores/ {print $4;exit}' /proc/cpuinfo)
+	CPU_SPEED=$(awk '/^cpu MHz/ {printf "%d", $4;exit}' /proc/cpuinfo)
+	BOGOMIPS=$(awk '/^bogomips/ {printf "%d", $3;exit}' /proc/cpuinfo)
+fi
+
+# Memory in MB
+MEM_TOTAL=$(awk '/MemTotal/ {printf "%d", $2/1024}' /proc/meminfo)
+
+echo "Total memory $MEM_TOTAL"
+echo "Number of CPU cores $CPU_CORES"
+echo "CPU speed $CPU_SPEED"
+echo "BogoMIPS $BOGOMIPS"
+
+echo "##################################################################"
+echo "# PHP-FPM"
+echo "##################################################################"
+# Determined in advance via "ps -ylC php-fpm --sort:rss"
+PHP_PROCESS_SIZE=65
+
+# Amount of RAM PHP can use
+PHP_AVAIL_RAM=$(awk "BEGIN {printf "'"%d"'", $MEM_TOTAL * 0.6 }")
+
+# Idling processes awaiting a connection
+PHP_MAX_SPARE_SERVERS=$(validate_params ${CPU_CORES} ${PHP_MAX_SPARE_SERVERS_DEFAULT})
+echo "The MAXIMUM number of idle PHP-FPM processes $PHP_MAX_SPARE_SERVERS"
+
+
+PHP_MIN_SPARE_SERVERS=$(validate_params $(( (${PHP_MAX_SPARE_SERVERS} / 4) + 1 )) ${PHP_MIN_SPARE_SERVERS_DEFAULT})
+echo "The MINIMUM number of idle PHP-FPM processes $PHP_MIN_SPARE_SERVERS"
+
+
+PHP_START_SERVERS=$(validate_params $(( ${PHP_MIN_SPARE_SERVERS} + (${PHP_MAX_SPARE_SERVERS} - ${PHP_MIN_SPARE_SERVERS}) / 2 )) ${PHP_START_SERVERS_DEFAULT})
+echo "The number of PHP-FPM child processes created on startup $PHP_START_SERVERS"
+
+# Max amount of children is based on memory
+
+PHP_MAX_CHILDREN=$(validate_params $(awk "BEGIN {printf "'"%d"'", $PHP_AVAIL_RAM / $PHP_PROCESS_SIZE }") ${PHP_MAX_CHILDREN_DEFAULT})
+echo "The maximum number of PHP-FPM child processes (max simultaneous requests) $PHP_MAX_CHILDREN"
+
+# This gives about 128MB of RAM per PHP process per 1GB of RAM
+
+PHP_MEMORY_LIMIT=$(validate_params $(awk "BEGIN {printf "'"%d"'", $MEM_TOTAL / 7 }") ${PHP_MEMORY_LIMIT_DEFAULT})
+echo "The maximum amount of memory allowed PER PHP-FPM PROCESS ${PHP_MEMORY_LIMIT}M"
+
+echo "##################################################################"
+echo "# APACHE MPM_EVENT"
+echo "##################################################################"
+# Determined in advance via "ps -ylC httpd --sort:rss"
+APACHE_PROCESS_SIZE=15
+
+# Amount of RAM Apache can use
+APACHE_AVAIL_RAM=$(awk "BEGIN {printf "'"%d"'", $MEM_TOTAL * 0.2 }")
+APACHE_MAX_ALLOWED_RAM=2000
+APACHE_AVAIL_RAM=$(( $APACHE_AVAIL_RAM > $APACHE_MAX_ALLOWED_RAM ? $APACHE_MAX_ALLOWED_RAM : $APACHE_AVAIL_RAM ))
+
+# Max amount of children is based on memory
+APACHE_SERVER_LIMIT=$(validate_params $(awk "BEGIN {printf "'"%d"'", ${APACHE_AVAIL_RAM} / ${APACHE_PROCESS_SIZE} }") ${APACHE_SERVER_LIMIT_DEFAULT})
+echo "The maximum number of Apache child processes $APACHE_SERVER_LIMIT"
+
+# Not calculated, defaults to 25. https://httpd.apache.org/docs/current/mod/mpm_common.html#threadsperchild
+echo "The number of Apache threads per child process $APACHE_THREADS_PER_CHILD"
+
+# Extra information given to the admin
+echo "The maximum number of simultaneous requests "$(( $APACHE_SERVER_LIMIT * APACHE_THREADS_PER_CHILD ))
+
+APACHE_MIN_SPARE_THREADS=$(validate_params $(awk "BEGIN {printf "'"%d"'", $APACHE_SERVER_LIMIT * 1.5 }") ${APACHE_APACHE_MIN_SPARE_THREADS_DEFAULT})
+echo "The MINIMUM number of idle Apache processes $APACHE_MIN_SPARE_THREADS"
+
+APACHE_MAX_SPARE_THREADS=$(validate_params $(( $APACHE_SERVER_LIMIT * 5 )) ${APACHE_APACHE_MAX_SPARE_THREADS_DEFAULT})
+echo "The MAXIMUM number of idle Apache processes $APACHE_MAX_SPARE_THREADS"
+
+# Defaults to 3. https://httpd.apache.org/docs/current/mod/mpm_common.html#startservers
+echo "The number of Apache child processes created on startup $APACHE_START_SERVERS"


### PR DESCRIPTION
Here is a brand new PHP component for the ownCloud snap.
- Uses PHP-FPM and Apache MPM event
- It makes some modifications to the Apache configs in order to be able to work hand in hand with Apache
- It introduces some structure for the location of logs, sockets and pids
- It introduces an auto-configuration script to help deliver an acceptable setup from the get go
- It lets users modify their configs, so that they can optimise them for their work load/case
### Deliveries
- [x] Configure Apache in mpm_event mode #27 
- [x] Remove the mod_php module
- [x] Create a part for building PHP
- [x] Add JPEG and TrueType support in PHP #26
- [x] Optimise PHP build
- [x] Create a PHP-FPM daemon
- [x] Create a phpinfo command
- [x] Automatically generate a default PHP-FPM config, tuned for the hardware the snap is installed on #28
- [x] Automatically generate a default Apache MPM event config, tuned for the hardware the snap is installed on #28
- [x] Build a file structure allowing for users to customise their configuration #41
- [x] Delete `.user.ini` and migrate settings to config files 
### Test plan

Snaps of this PR for your beta PiClouds will be available once Snapcraft 2.8 has been packaged as a PPA.

Sideloading instructions:
https://github.com/owncloud/pi-image/wiki/Sideloading-snaps-for-testing
- Make sure the platform.conf files are properly populated
- After setup, go to the admin section and you should only get warnings about the missing Redis and HTTPS components
- Upload a few PNG, GIF and JPEGs, you should get previews
- Sync a 123MB folder using the sync client. The device should never become unresponsive
### TODO
- [ ] Approve #28
- [ ] Maybe remove more assets such as documentation from PHP
- [x] Fix `if [ $1 -gt 0 ]; then` to make it work when the value is empty
### Examples configs

Pi 2

```
##################################################################
# HARDWARE
##################################################################
Total memory 921
Number of CPU cores 4
CPU speed 900
BogoMIPS 38
##################################################################
# PHP-FPM
##################################################################
The MAXIMUM number of idle PHP-FPM processes 4
The MINIMUM number of idle PHP-FPM processes 2
The number of PHP-FPM child processes created on startup 3
The maximum number of PHP-FPM child processes (max simultaneous requests) 8
The maximum amount of memory allowed PER PHP-FPM PROCESS 131M
##################################################################
# APACHE MPM_EVENT
##################################################################
The maximum number of Apache child processes 12
The number of Apache threads per child process 25
The maximum number of simultaneous requests 300
The MINIMUM number of idle Apache processes 18
The MAXIMUM number of idle Apache processes 60
The number of Apache child processes created on startup 3
```
