### PR TITLE
Expose MySQL client.

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -18,6 +18,11 @@ apps:
     daemon: simple
     plugs: [listener]
 
+  # MySQL client
+  mysql-client:
+    command: mysql --defaults-file=$SNAP_DATA/mysql/root.ini
+    plugs: [listener]
+
   # mDNS daemon
   mdns-publisher:
     command: delay-on-failure mdns-publisher owncloud


### PR DESCRIPTION
ownCloud doesn't handle migrating an install, which means in order to do so one must directly access the database. The current snap doesn't expose a MySQL client, so such a thing is currently difficult. This
PR fixes #37 by exposing the MySQL client as an app, which will use the root MySQL user.
