### PR TITLE
Upgrade to ownCloud 9.0.1.

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: owncloud
-version: 9.0.0ubuntu1
+version: 9.0.1ubuntu1
 summary: ownCloud
 description: ownCloud running on Apache with MySQL. This is currently in beta.
 
@@ -44,7 +44,7 @@ parts:
     plugin: apache
     source: https://github.com/kyrofa/owncloud.git
     source-type: git
-    source-tag: 9.0.0
+    source-tag: 9.0.1
 
     # The built-in Apache modules to enable
     modules:

--- a/src/owncloud/apache_config
+++ b/src/owncloud/apache_config
@@ -11,6 +11,20 @@ Alias "/apps" "${SNAP_DATA}/owncloud/apps"
     Require all granted
 </Directory>
 
-<IfModule dir_module>
-    DirectoryIndex index.html index.php
-</IfModule>
+<Directory "${SNAP}/htdocs">
+    # Include ownCloud's .htaccess file directly. In a typical setup this would
+    # be dangerous since it increases the capability of the .htaccess file in
+    # case an attacker was able to modify it, but that's not actually possible
+    # on Snappy (since the .htaccess file is read-only) so we'll do it here so
+    # as to avoid manually copying it in and needing to maintain it.
+    Include ${SNAP}/htdocs/.htaccess
+
+    # Increase the max upload size, and upload into a different tmp so we don't
+    # try to use that much RAM.
+    php_value upload_max_filesize 16G
+    php_value post_max_size 16G
+    php_value upload_tmp_dir ${SNAP_DATA}/owncloud/tmp
+
+    # Note that nothing else is included here as this directive is merged with
+    # the one in the main configuration file.
+</Directory>

--- a/src/php/php.ini
+++ b/src/php/php.ini
@@ -653,7 +653,7 @@ auto_globals_jit = On
 ; Its value may be 0 to disable the limit. It is ignored if POST data reading
 ; is disabled through enable_post_data_reading.
 ; http://php.net/post-max-size
-post_max_size = 16G
+post_max_size = 8M
 
 ; Automatically add files before PHP document.
 ; http://php.net/auto-prepend-file
@@ -792,11 +792,11 @@ file_uploads = On
 ; Temporary directory for HTTP uploaded files (will use system default if not
 ; specified).
 ; http://php.net/upload-tmp-dir
-upload_tmp_dir = ${SNAP_DATA}/owncloud/tmp
+;upload_tmp_dir =
 
 ; Maximum allowed size for uploaded files.
 ; http://php.net/upload-max-filesize
-upload_max_filesize = 16G
+upload_max_filesize = 2M
 
 ; Maximum number of files that can be uploaded via a single request
 max_file_uploads = 20


### PR DESCRIPTION
This PR fixes #54 by upgrading ownCloud to 9.0.1. It also starts using the .htaccess file shipped in the root of ownCloud. Note that this was done with a direct include rather than enabling overrides due to the performance penalty. Typically this would be unsafe, but the dangers are negated by the fact that the .htaccess file is read-only.
