### PR TITLE
Release 9.0.1ubuntu1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,15 @@
+v 9.0.1ubuntu1
+  - MySQL: Increase max allowed packet.
+  - PHP: Enable logging.
+  - Upgrade to ownCloud 9.0.1.
+  - MySQL: Expose client as an app.
+  - Make ownCloud upgrade failure fatal.
+  - Increase max upload to 16GB.
+  - Handle removal of $SNAP_DEVELOPER.
+  - Make occ look in $SNAP for php.ini
+  - MySQL: Remove libnuma as a dependency.
+  - Add Apache plugin
+
 v 9.0.0ubuntu1
   - Don't rely on cwd being $SNAP.
   - Move from SNAP_FULLNAME to SNAP_NAME.SNAP_DEVELOPER.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Snappy ownCloud
 
-ownCloud 9.0.0 packaged as a .snap for Ubuntu Core. It consists of:
+ownCloud server packaged as a .snap for Ubuntu Core. It consists of:
 
-- ownCloud 9.0.0
+- ownCloud 9.0.1
 - Apache 2.4
 - PHP 7
-- mysql 5.7.11
+- mysql 5.7
 - mDNS for network discovery
 
 
@@ -18,7 +18,7 @@ This ownCloud .snap is only available on Snappy Ubuntu Core 16.04. Install via:
 
 ## How to use
 
-After install, assuming the Ubuntu Core device is on the same network as you,
+After install, assuming you and the Ubuntu Core device are on the same network,
 you should be able to reach the ownCloud installation by visiting
 `owncloud.local` in your browser (note that if you change the hostname, it'll be
 `<hostname>.local`).

--- a/parts/plugins/x-apache.py
+++ b/parts/plugins/x-apache.py
@@ -99,8 +99,8 @@ class ApachePlugin(snapcraft.BasePlugin):
 
         return schema
 
-    def __init__(self, name, options):
-        super().__init__(name, options)
+    def __init__(self, name, options, project):
+        super().__init__(name, options, project)
 
         self.build_packages.extend(
             ['pkg-config', 'libapr1-dev', 'libaprutil1-dev', 'libpcre3-dev',
@@ -188,7 +188,7 @@ class ApachePlugin(snapcraft.BasePlugin):
 
         self.run(
             ['make', '-j{}'.format(
-                snapcraft.common.get_parallel_build_count())],
+                self.project.parallel_build_count)],
             cwd=apache_build_directory)
         self.run(['make', 'install'], cwd=apache_build_directory)
 
@@ -251,7 +251,7 @@ class ApachePlugin(snapcraft.BasePlugin):
             self.run(configure_command + module.configflags,
                      cwd=module_build_directory)
             self.run(['make', '-j{}'.format(
-                snapcraft.common.get_parallel_build_count())],
+                self.project.parallel_build_count)],
                 cwd=module_build_directory)
             self.run(['make', 'install'], cwd=module_build_directory)
 

--- a/parts/plugins/x-apache.py
+++ b/parts/plugins/x-apache.py
@@ -141,7 +141,7 @@ class ApachePlugin(snapcraft.BasePlugin):
                     self.options.extra_configuration))
 
         apache_source_directory = os.path.join(self.apache_directory, 'src')
-        apache_sources = snapcraft.sources.Tar('http://ftp.wayne.edu/apache/httpd/httpd-2.4.18.tar.gz', apache_source_directory)
+        apache_sources = snapcraft.sources.Tar('http://ftp.wayne.edu/apache/httpd/httpd-2.4.20.tar.gz', apache_source_directory)
 
         os.makedirs(apache_source_directory)
 

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -18,6 +18,11 @@ apps:
     daemon: simple
     plugs: [listener]
 
+  # MySQL client
+  mysql-client:
+    command: mysql --defaults-file=$SNAP_DATA/mysql/root.ini
+    plugs: [listener]
+
   # mDNS daemon
   mdns-publisher:
     command: delay-on-failure mdns-publisher owncloud

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -44,7 +44,7 @@ parts:
     plugin: apache
     source: https://github.com/kyrofa/owncloud.git
     source-type: git
-    source-tag: 9.0.0
+    source-tag: 9.0.1
 
     # The built-in Apache modules to enable
     modules:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: owncloud
-version: 9.0.0ubuntu1
+version: 9.0.1ubuntu1
 summary: ownCloud
 description: ownCloud running on Apache with MySQL. This is currently in beta.
 
@@ -87,7 +87,9 @@ parts:
       - -manual # No need to include the documentation in the .snap
       - -htdocs/.git*
     stage-packages:
-      - libxml2 # Only included here until the OS snap stabilizes
+      # These are only included here until the OS snap stabilizes
+      - libxml2
+      - libpng12-0
     build-packages:
       - libxml2-dev
       - libcurl4-openssl-dev

--- a/src/mysql/my.cnf
+++ b/src/mysql/my.cnf
@@ -1,4 +1,5 @@
 [mysqld]
 user=root
+max_allowed_packet=100M
 secure-file-priv=NULL
 skip-networking

--- a/src/owncloud/apache_config
+++ b/src/owncloud/apache_config
@@ -11,6 +11,20 @@ Alias "/apps" "${SNAP_DATA}/owncloud/apps"
     Require all granted
 </Directory>
 
-<IfModule dir_module>
-    DirectoryIndex index.html index.php
-</IfModule>
+<Directory "${SNAP}/htdocs">
+    # Include ownCloud's .htaccess file directly. In a typical setup this would
+    # be dangerous since it increases the capability of the .htaccess file in
+    # case an attacker was able to modify it, but that's not actually possible
+    # on Snappy (since the .htaccess file is read-only) so we'll do it here so
+    # as to avoid manually copying it in and needing to maintain it.
+    Include ${SNAP}/htdocs/.htaccess
+
+    # Increase the max upload size, and upload into a different tmp so we don't
+    # try to use that much RAM.
+    php_value upload_max_filesize 16G
+    php_value post_max_size 16G
+    php_admin_value upload_tmp_dir ${SNAP_DATA}/owncloud/tmp
+
+    # Note that nothing else is included here as this directive is merged with
+    # the one in the main configuration file.
+</Directory>

--- a/src/owncloud/setup_owncloud
+++ b/src/owncloud/setup_owncloud
@@ -54,6 +54,25 @@ else
 	fi
 fi
 
-# Finally, make sure ownCloud is up to date
-echo "Upgrading ownCloud..."
+# Finally, make sure ownCloud is up to date. The return code of the upgrade
+# can be used to determine the outcome:
+#    succes = 0;
+#    not installed = 1;
+#    in maintenance mode = 2;
+#    already up to date = 3;
+#    invalid arguments  = 4;
+#    other failure = 5;
+echo "Making sure ownCloud is fully upgraded..."
 occ upgrade --no-interaction
+return_code=$?
+if [ $return_code -eq 1 ]; then
+	echo "ownCloud is not yet installed-- no upgrade necessary"
+elif [ $return_code -eq 3 ]; then
+	echo "ownCloud is fully upgraded"
+elif [ $return_code -ne 0 ]; then
+	echo "Unable to upgrade ownCloud. Will try again."
+	# occ may have left it in maintenance mode, so turn that off
+	occ maintenance:mode --off
+	sleep 10 # Delaying here so systemd doesn't throttle us
+	exit 1
+fi

--- a/src/owncloud/setup_owncloud
+++ b/src/owncloud/setup_owncloud
@@ -29,6 +29,9 @@ fi
 # Make sure owncloud directory exists
 mkdir -p $SNAP_DATA/owncloud
 
+# Make sure owncloud tmp directory exists
+mkdir -p $SNAP_DATA/owncloud/tmp
+
 # Make sure apps are up to date
 echo "Ensuring ownCloud apps are up-to-date..."
 OWNCLOUD_APPS_DIR=$SNAP_DATA/owncloud/apps

--- a/src/php/php.ini
+++ b/src/php/php.ini
@@ -568,6 +568,7 @@ html_errors = On
 ;error_log = php_errors.log
 ; Log errors to syslog (Event Log on Windows).
 ;error_log = syslog
+error_log = ${SNAP_DATA}/apache/logs/php_errors.log
 
 ;windows.show_crt_warning
 ; Default value: 0

--- a/src/php/php.ini
+++ b/src/php/php.ini
@@ -653,7 +653,7 @@ auto_globals_jit = On
 ; Its value may be 0 to disable the limit. It is ignored if POST data reading
 ; is disabled through enable_post_data_reading.
 ; http://php.net/post-max-size
-post_max_size = 8M
+post_max_size = 16G
 
 ; Automatically add files before PHP document.
 ; http://php.net/auto-prepend-file
@@ -792,11 +792,11 @@ file_uploads = On
 ; Temporary directory for HTTP uploaded files (will use system default if not
 ; specified).
 ; http://php.net/upload-tmp-dir
-;upload_tmp_dir =
+upload_tmp_dir = ${SNAP_DATA}/owncloud/tmp
 
 ; Maximum allowed size for uploaded files.
 ; http://php.net/upload-max-filesize
-upload_max_filesize = 2M
+upload_max_filesize = 16G
 
 ; Maximum number of files that can be uploaded via a single request
 max_file_uploads = 20

--- a/src/php/php.ini
+++ b/src/php/php.ini
@@ -653,7 +653,7 @@ auto_globals_jit = On
 ; Its value may be 0 to disable the limit. It is ignored if POST data reading
 ; is disabled through enable_post_data_reading.
 ; http://php.net/post-max-size
-post_max_size = 16G
+post_max_size = 8M
 
 ; Automatically add files before PHP document.
 ; http://php.net/auto-prepend-file
@@ -792,11 +792,11 @@ file_uploads = On
 ; Temporary directory for HTTP uploaded files (will use system default if not
 ; specified).
 ; http://php.net/upload-tmp-dir
-upload_tmp_dir = ${SNAP_DATA}/owncloud/tmp
+;upload_tmp_dir =
 
 ; Maximum allowed size for uploaded files.
 ; http://php.net/upload-max-filesize
-upload_max_filesize = 16G
+upload_max_filesize = 2M
 
 ; Maximum number of files that can be uploaded via a single request
 max_file_uploads = 20


### PR DESCRIPTION
- MySQL: Increase max allowed packet.
- PHP: Enable logging.
- Upgrade to ownCloud 9.0.1.
- MySQL: Expose client as an app.
- Make ownCloud upgrade failure fatal.
- Increase max upload to 16GB.
- Handle removal of $SNAP_DEVELOPER.
- Make occ look in $SNAP for php.ini
- MySQL: Remove libnuma as a dependency.
- Add Apache plugin
