### PR TITLE
Release 9.0.1ubuntu2

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,11 @@
+v 9.0.1ubuntu2
+  - Update for series 16.
+  - Break backward compatibility with version on rolling.
+  - Use real interfaces.
+  - Use the common directory for ownCloud data.
+  - Use two app folders: the read-only in-snap apps, and user-installed ones in
+    $SNAP_DATA.
+
 v 9.0.1ubuntu1
   - MySQL: Increase max allowed packet.
   - PHP: Enable logging.

--- a/README.md
+++ b/README.md
@@ -11,29 +11,44 @@ ownCloud server packaged as a .snap for Ubuntu Core. It consists of:
 
 ## How to install
 
-This ownCloud .snap is only available on Snappy Ubuntu Core 16.04. Install via:
+This ownCloud .snap is available in the store for release series 16 (e.g. Ubuntu
+16.04). Install via:
 
-    $ sudo snappy install owncloud
+    $ sudo snap install owncloud
 
 
 ## How to use
 
 After install, assuming you and the Ubuntu Core device are on the same network,
 you should be able to reach the ownCloud installation by visiting
-`owncloud.local` in your browser (note that if you change the hostname, it'll be
-`<hostname>.local`).
+`<hostname>.local` in your browser. If your hostname is `localhost` or
+`localhost.localdomain`, like on an Ubuntu Core device, `owncloud.local` will be
+used instead.
 
 Upon visiting the ownCloud installation for the first time, you'll be prompted
 for an admin username and password. After you provide that information you'll be
 logged in and able to create users, install apps, and upload files.
 
 
-## Limitations
+### Included CLI utilities
 
-Ideally ownCloud would be able to store its raw data outside of the Snappy data
-directories (e.g. on an external hard drive while installed on a raspberry pi).
-However, .snaps currently do not have the ability to access the filesystem
-outside of the Snappy data directories (Ubuntu Core 16.04 will include this,
-it's just not done yet). As a result, the ownCloud data directory is contained
-within `$SNAP_DATA`, which means it's migrated upon upgrade, which can waste
-quite a bit of hard drive space. This will be improved soon.
+There are a few CLI utilities included:
+
+- `owncloud.occ`:
+    - ownCloud's `occ` configuration tool. Note that it requires `sudo`.
+- `owncloud.mysql-client`:
+    - MySQL client preconfigured to communicate with ownCloud MySQL server. This
+      may be useful in case you need to migrate ownCloud installations. Note
+      this it requires `sudo`.
+
+
+## Where is my stuff?
+
+- `$SNAP_DATA`:
+    - Apache and MySQL logs
+    - MySQL database
+    - ownCloud config
+    - Any ownCloud apps installed by the user
+- `$SNAP_DATA/../common` (unversioned directory):
+    - ownCloud data
+    - ownCloud logs

--- a/parts/plugins/x-apache.py
+++ b/parts/plugins/x-apache.py
@@ -259,7 +259,8 @@ class ApachePlugin(snapcraft.BasePlugin):
         # Setup startup script (piggybacking on envvars)
         with open(os.path.join(self.installdir, 'bin', 'envvars'), 'w') as f:
             f.write('# Make sure log directory exists\n')
-            f.write('mkdir -p ${SNAP_DATA}/apache/logs')
+            f.write('mkdir -p -m 750 ${SNAP_DATA}/apache\n')
+            f.write('mkdir -p -m 750 ${SNAP_DATA}/apache/logs')
 
             if self.options.startup_script:
                 f.write('\n. ${{SNAP}}/{}'.format(self.startup_file_path))

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: owncloud
-version: 9.0.1ubuntu1
+version: 9.0.1ubuntu2
 summary: ownCloud
 description: ownCloud running on Apache with MySQL. This is currently in beta.
 confinement: strict

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -2,6 +2,7 @@ name: owncloud
 version: 9.0.1ubuntu1
 summary: ownCloud
 description: ownCloud running on Apache with MySQL. This is currently in beta.
+confinement: strict
 
 apps:
   # Apache daemon
@@ -9,35 +10,30 @@ apps:
     command: apachectl start -DFOREGROUND
     stop-command: apachectl stop
     daemon: simple
-    plugs: [listener]
+    plugs: [network, network-bind]
 
   # MySQL daemon
   mysql:
     command: start_mysql
     stop-command: support-files/mysql.server stop
     daemon: simple
-    plugs: [listener]
+    plugs: [network, network-bind]
 
   # MySQL client
   mysql-client:
     command: mysql --defaults-file=$SNAP_DATA/mysql/root.ini
-    plugs: [listener]
+    plugs: [network, network-bind]
 
   # mDNS daemon
   mdns-publisher:
     command: delay-on-failure mdns-publisher owncloud
     daemon: simple
-    plugs: [listener]
+    plugs: [network, network-bind]
 
   # ownCloud occ command
   occ:
     command: occ
-    plugs: [listener]
-
-plugs:
-  listener:
-    interface: old-security
-    caps: [network-listener]
+    plugs: [network, network-bind]
 
 parts:
   apache:

--- a/src/owncloud/apache_config
+++ b/src/owncloud/apache_config
@@ -5,8 +5,8 @@
 PHPIniDir "${SNAP}/php.ini"
 
 # Serve static assets for apps in a writable location.
-Alias "/apps" "${SNAP_DATA}/owncloud/apps"
-<Directory "${SNAP_DATA}/owncloud/apps">
+Alias "/extra-apps" "${SNAP_DATA}/owncloud/extra-apps"
+<Directory "${SNAP_DATA}/owncloud/extra-apps">
     AllowOverride None
     Require all granted
 </Directory>
@@ -23,7 +23,8 @@ Alias "/apps" "${SNAP_DATA}/owncloud/apps"
     # try to use that much RAM.
     php_value upload_max_filesize 16G
     php_value post_max_size 16G
-    php_admin_value upload_tmp_dir ${SNAP_DATA}/owncloud/tmp
+    # FIXME: Use common environment variable when it exists.
+    php_admin_value upload_tmp_dir ${SNAP_DATA}/../common/owncloud/tmp
 
     # Note that nothing else is included here as this directive is merged with
     # the one in the main configuration file.

--- a/src/owncloud/autoconfig.php
+++ b/src/owncloud/autoconfig.php
@@ -1,19 +1,12 @@
 <?php
 
 $snap_name = getenv('SNAP_NAME');
-$snap_developer = getenv('SNAP_DEVELOPER');
-if ($snap_developer == '') {
-	$snap_developer = getenv('SNAP_ORIGIN');
-}
 
-if ($snap_developer != '') {
-	$snap_name = $snap_name . '.' . $snap_developer;
-}
-
-$data_path = '/var/lib/snaps/'.$snap_name.'/current';
+$data_path = '/var/snap/'.$snap_name.'/current';
+$common_data_path = '/var/snap/'.$snap_name.'/common';
 
 $AUTOCONFIG = array(
-'directory' => $data_path.'/owncloud/data',
+'directory' => $common_data_path.'/owncloud/data',
 
 'dbtype' => 'mysql',
 

--- a/src/owncloud/config.php
+++ b/src/owncloud/config.php
@@ -1,14 +1,6 @@
 <?php
 
 $snap_name = getenv('SNAP_NAME');
-$snap_developer = getenv('SNAP_DEVELOPER');
-if ($snap_developer == '') {
-	$snap_developer = getenv('SNAP_ORIGIN');
-}
-
-if ($snap_developer != '') {
-	$snap_name = $snap_name . '.' . $snap_developer;
-}
 
 $CONFIG = array(
 /**
@@ -20,9 +12,21 @@ $CONFIG = array(
  * indicates if a web server can write files to that folder.
  */
 'apps_paths' => array(
+	/**
+	 * These are the default apps shipped with ownCloud. They are read-only.
+	 */
 	array(
-		'path'=> '/var/lib/snaps/'.$snap_name.'/current/owncloud/apps',
+		'path'=> '/snap/'.$snap_name.'/current/htdocs/apps',
 		'url' => '/apps',
+		'writable' => false,
+	),
+
+	/**
+	 * This directory is writable, meant for apps installed by the user.
+	 */
+	array(
+		'path'=> '/var/snap/'.$snap_name.'/current/owncloud/extra-apps',
+		'url' => '/extra-apps',
 		'writable' => true,
 	),
 ),

--- a/src/owncloud/setup_owncloud
+++ b/src/owncloud/setup_owncloud
@@ -27,31 +27,21 @@ else
 fi
 
 # Make sure owncloud directory exists
-mkdir -p $SNAP_DATA/owncloud
+# FIXME: Use common environment variable when it exists
+mkdir -p -m 750 $SNAP_DATA/../common/owncloud
 
 # Make sure owncloud tmp directory exists
-mkdir -p $SNAP_DATA/owncloud/tmp
+# FIXME: Use common environment variable when it exists
+mkdir -p -m 750 $SNAP_DATA/../common/owncloud/tmp
 
-# Make sure apps are up to date
-echo "Ensuring ownCloud apps are up-to-date..."
-OWNCLOUD_APPS_DIR=$SNAP_DATA/owncloud/apps
-mkdir -p $OWNCLOUD_APPS_DIR
-cp -r $SNAP/htdocs/apps/. $OWNCLOUD_APPS_DIR
+# Make sure owncloud extra-apps directory exists (for user apps)
+mkdir -p -m 750 $SNAP_DATA/owncloud/extra-apps
 
 # If this is a new install, make sure it's configured correctly
 export OWNCLOUD_CONFIG_DIR=$SNAP_DATA/owncloud/config
 if [ ! -d "$OWNCLOUD_CONFIG_DIR" ]; then
 	echo "Configuring ownCloud..."
 	cp -r $SNAP/htdocs/config $OWNCLOUD_CONFIG_DIR
-else
-	# This is not a new installation, so we don't want to override
-	# the config. We do, however, want to make sure we incorporate
-	# the new options for ownCloud 9-- namely, disabling code
-	# signing. Only set that option if it hasn't already been set.
-	occ config:system:get integrity.check.disabled
-	if [ $? -eq 1 ]; then
-		occ config:system:set integrity.check.disabled --value=true --type=boolean
-	fi
 fi
 
 # Finally, make sure ownCloud is up to date. The return code of the upgrade


### PR DESCRIPTION
- Update for series 16.
- Break backward compatibility with version on rolling.
- Use real interfaces.
- Use the common directory for ownCloud data.
- Use two app folders: the read-only in-snap apps, and user-installed ones in `$SNAP_DATA`.
